### PR TITLE
Added spif datatype and sniffer

### DIFF
--- a/lib/galaxy/config/sample/datatypes_conf.xml.sample
+++ b/lib/galaxy/config/sample/datatypes_conf.xml.sample
@@ -986,6 +986,8 @@
     <!-- Flexible Image Transport System (FITS) used in Astronomy https://fits.gsfc.nasa.gov/ https://fits.gsfc.nasa.gov/rfc4047.txt -->
     <datatype extension="fits" type="galaxy.datatypes.binary:FITS" mimetype="application/octet-stream" display_in_upload="true" description="Flexible Image Transport System (FITS) used in Astronomy"/>
     <datatype extension="chain" type="galaxy.datatypes.chain:Chain" display_in_upload="true"/>
+    <!-- Moonshot datatypes -->
+    <datatype extension="spif" type="galaxy.datatypes.triples:Spif" display_in_upload="true"/>
   </registration>
   <sniffers>
     <!--
@@ -1090,6 +1092,7 @@
     <sniffer type="galaxy.datatypes.annotation:Augustus"/>
     <sniffer type="galaxy.datatypes.xml:Owl"/>
     <sniffer type="galaxy.datatypes.chain:Chain"/>
+    <sniffer type="galaxy.datatypes.triples:Spif"/>
     <sniffer type="galaxy.datatypes.triples:Rdf"/>
     <sniffer type="galaxy.datatypes.blast:BlastXml"/>
     <sniffer type="galaxy.datatypes.images:Gifti" />
@@ -1270,5 +1273,8 @@
     <sniffer type="galaxy.datatypes.text:BCSLmodel"/>
     <sniffer type="galaxy.datatypes.text:StormSample"/>
     <sniffer type="galaxy.datatypes.text:StormCheck"/>
+
+    <!-- Moonshot sniffers -->
+    <sniffer type="galaxy.datatypes.triples:ProgrammingLanguageIndependentFormat"/>
   </sniffers>
 </datatypes>


### PR DESCRIPTION
## Added spif datatype and sniffer
By adding a new line in the registration list of datatypes and sniffers list of sniffers in the `datatypes_conf.xml.sample` file. I've added the SPIF datatype and linked to its sniffer. 

The sniffer is specified in triples.py and uses Triples as a sort of abstraction. In triples.py under the Spif class I decided to sniff for `xmlns:SEON_code="http://se-on.org/ontologies/domain-specific/2012/02/code.owl#"` in the XML file header to decide if it is spif or not. Moreover, I decided to keep the legacy RDF check since it is also RDF, sniffing needs to be done from strict to lose and the spif check should come before the rdf check. Note that I refactored this though.

With these additions, Auto-detect for formats should now result in the spif format for spif file uploads.

### Branch goals
- [x] Add spif datatype.
- [x] Add spif sniffer.

### Video-Proof

https://github.com/Moonshot-SEP/galaxy/assets/104417251/7ef6ffe0-3be8-4b99-9120-77e3e2095cd1

